### PR TITLE
fix: strides are not defined for v9-s and v9-m

### DIFF
--- a/yolo/config/model/v9-m.yaml
+++ b/yolo/config/model/v9-m.yaml
@@ -2,6 +2,7 @@ name: v9-m
 
 anchor:
   reg_max: 16
+  strides: [8, 16, 32]
 
 model:
   backbone:

--- a/yolo/config/model/v9-s.yaml
+++ b/yolo/config/model/v9-s.yaml
@@ -2,6 +2,7 @@ name: v9-s
 
 anchor:
   reg_max: 16
+  strides: [8, 16, 32]
 
 model:
   backbone:


### PR DESCRIPTION
Anchor strides are not defined for small (v9-s) and medium (v9-m) model versions.

This has the impact of increasing model initialization time since they need to define what anchors were generated by testing different strides at runtime. This specific test can also fail under specific conditions (mismatch between torch arrays and numpy arrays).